### PR TITLE
Fix log4shell

### DIFF
--- a/Jenkinsfile-Test.groovy
+++ b/Jenkinsfile-Test.groovy
@@ -9,7 +9,10 @@ pipeline {
     environment {
         TESTSERVER_TOMCAT_ENDPOINT = "http://alpinebits-server.tomcat02.testingmachine.eu:8080/manager/text"
         TESTSERVER_TOMCAT_CREDENTIALS = credentials('testserver-tomcat8-credentials')
-        ODH_URL = "https://tourism.opendatahub.bz.it"
+        ODH_URL = "https://api.tourism.testingmachine.eu/v1"
+        ODH_AUTH_URL = "https://auth.opendatahub.testingmachine.eu/auth/realms/noi/protocol/openid-connect/token"
+        ODH_AUTH_CLIENT_ID = credentials('odh-authserver-tourism-api-test-clientid')
+        ODH_AUTH_CLIENT_SECRET = credentials('odh-authserver-tourism-api-test-clientsecret')
     }
 
     stages {
@@ -22,6 +25,9 @@ pipeline {
                 sh 'echo "</settings>" >> ~/.m2/settings.xml'
 
                 sh 'sed -i -e "s%\\(odh.url\\s*=\\).*\\$%\\1${ODH_URL}%" application-war/src/main/resources/application.properties'
+                sh 'sed -i -e "s%\\(odh.auth.url\\s*=\\).*\\$%\\1${ODH_AUTH_URL}%" application-war/src/main/resources/application.properties'
+                sh 'sed -i -e "s%\\(odh.auth.client.id\\s*=\\).*\\$%\\1${ODH_AUTH_CLIENT_ID}%" application-war/src/main/resources/application.properties'
+                sh 'sed -i -e "s%\\(odh.auth.client.secret\\s*=\\).*\\$%\\1${ODH_AUTH_CLIENT_SECRET}%" application-war/src/main/resources/application.properties'
             }
         }
         stage('Test') {

--- a/application-spring/pom.xml
+++ b/application-spring/pom.xml
@@ -32,7 +32,7 @@
         <janino.version>3.0.12</janino.version>
         <jersey.version>2.30</jersey.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j-slf4j-impl.version>2.11.1</log4j-slf4j-impl.version>
+        <log4j2.version>2.16.0</log4j2.version>
 
         <checkstyle-maven.version>3.1.1</checkstyle-maven.version>
         <checkstyle.version>8.29</checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <odh-alpinebits.version>2.0.2</odh-alpinebits.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j-slf4j-impl.version>2.11.1</log4j-slf4j-impl.version>
+        <log4j2.version>2.16.0</log4j2.version>
 
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>


### PR DESCRIPTION
This project does not use log4j, but it allows to use Spring to create and start a fat jar. Spring in turn defines a dependency on log4j-api (not vulnerable) which could be extended to use log4j-core (vulnerable). Therefore it is best to define the secure log4j version in case someone uses log4j in the future.