### PR TITLE
Fix certification audit feedback

### DIFF
--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
@@ -10,6 +10,7 @@
 
 package it.bz.opendatahub.alpinebitsserver.application.spring.middleware;
 
+import it.bz.opendatahub.alpinebits.common.constants.AlpineBitsAction;
 import it.bz.opendatahub.alpinebits.common.context.RequestContextKey;
 import it.bz.opendatahub.alpinebits.common.exception.AlpineBitsException;
 import it.bz.opendatahub.alpinebits.middleware.Context;
@@ -23,11 +24,20 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This middleware extracts the multipart/form-data from the request.
  */
 public class MultipartFormExtractorMiddleware implements Middleware {
+
+    // List of actions that do not require a "request" part
+    private final List<String> actionsWithoutRequest = Arrays.asList(
+            AlpineBitsAction.GET_VERSION,
+            AlpineBitsAction.GET_CAPABILITIES
+    );
 
     @Override
     public void handleContext(Context ctx, MiddlewareChain chain) {
@@ -36,12 +46,18 @@ public class MultipartFormExtractorMiddleware implements Middleware {
 
             Part actionPart = httpServletRequest.getPart("action");
             if (actionPart == null) {
-                throw new AlpineBitsException("No \"action\" parameter provided", 400);
+                throw new AlpineBitsException("unknown or missing action", 400);
             }
             String action = IOUtils.toString(actionPart.getInputStream(), StandardCharsets.UTF_8);
             ctx.put(RequestContextKey.REQUEST_ACTION, action);
 
             Part requestPart = httpServletRequest.getPart("request");
+
+            // Check if the action requires a request part
+            if (requestPart == null && !actionsWithoutRequest.contains(action)) {
+                throw new AlpineBitsException("unknown or missing \"request\" param", 400);
+            }
+
             if (requestPart != null) {
                 InputStream request = requestPart.getInputStream();
                 ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, request);

--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
@@ -35,7 +35,10 @@ public class MultipartFormExtractorMiddleware implements Middleware {
             HttpServletRequest httpServletRequest = ctx.getOrThrow(ServletContextKey.SERVLET_REQUEST);
 
             Part actionPart = httpServletRequest.getPart("action");
-            String action = IOUtils.toString(actionPart.getInputStream());
+            if (actionPart == null) {
+                throw new AlpineBitsException("No \"action\" parameter provided", 400);
+            }
+            String action = IOUtils.toString(actionPart.getInputStream(), StandardCharsets.UTF_8);
             ctx.put(RequestContextKey.REQUEST_ACTION, action);
 
             Part requestPart = httpServletRequest.getPart("request");

--- a/odh-backend/api/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/auth/AuthenticationException.java
+++ b/odh-backend/api/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/auth/AuthenticationException.java
@@ -10,12 +10,16 @@
 
 package it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.auth;
 
+import it.bz.opendatahub.alpinebits.common.exception.AlpineBitsException;
+
 /**
- * This exception is thrown if an authentication attempt was not successful.
+ * This exception is thrown when the authentication for a request was not successful.
  */
-public class AuthenticationException extends RuntimeException {
+public class AuthenticationException extends AlpineBitsException {
+
+    public static final int STATUS = 401;
 
     public AuthenticationException(String message, Throwable cause) {
-        super(message, cause);
+        super(message, STATUS, cause);
     }
 }


### PR DESCRIPTION
@sseppi @RudiThoeni @mrabans This PR fixes the following issues raised by the "Certification Audit Report for AlpineBits HotelData 2022-10 Server":

- support for anonymous access was removed, it returned open data previously. Any request with invalid credentials now returns a response with status code `401`
- missing action or request: the server now returns with the correct status code `400`, when the request params `action` or `request` are missing. Note that there is an exemption for this rule for the `Housekeeping` actions in AlpineBits versions < 2018-10; those actions don't need the `request` parameter

One topic, raised by the review, remains open after this PR gets merged:

- hotel-info pull before push: this generates an error, but since it is (quote from review) "not a typical use case", this PR won't fix the issue, further discussion may be needed