### PR TITLE
Migrate to Java 25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   PROJECT_NAME: odh-alpinebits-server
   DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}-app
   DOCKER_TAG: ${{ github.sha }}
-  JAVA_VERSION: '8'
+  JAVA_VERSION: '25'
 
 jobs:
   # Test

--- a/README.MD
+++ b/README.MD
@@ -35,7 +35,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 To build the project, the following prerequisites must be met:
 
-- Java JDK 1.8 or higher (e.g. [OpenJDK](https://openjdk.java.net/))
+- Java JDK 25 or higher (e.g. [OpenJDK](https://openjdk.java.net/))
 - [Maven](https://maven.apache.org/) 3.x
 
 If you want to run the application using [Docker](https://www.docker.com/), the environment is already set up with all dependencies for you. You only have to install [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) and follow the instruction in the [dedicated section](#execute-with-docker).

--- a/README.MD
+++ b/README.MD
@@ -85,7 +85,7 @@ Copy the file `.env.example` to `.env` and adjust the configuration parameters.
 Then you can start the application using the following command:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 The service will be available at localhost and your specified server port.
@@ -93,7 +93,7 @@ The service will be available at localhost and your specified server port.
 To execute the test you can run the following command:
 
 ```bash
-docker-compose run --rm app mvn clean test
+docker compose run --rm app mvn clean test
 ```
 
 ## Information

--- a/README.MD
+++ b/README.MD
@@ -29,7 +29,7 @@ The server implementation in this repository depends on the [AlpineBits library]
 
 ## Getting started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. Take a look at the [Deployment](#deployment) section for notes on how to deploy the project on a live system.
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
 ### Prerequisites
 

--- a/README.MD
+++ b/README.MD
@@ -67,7 +67,7 @@ mvn -Dspring.profiles.active=local clean install
 Run the project:
 
 ```bash
-mvn -Dspring.profiles.active=local spring-boot:run
+mvn -Dspring-boot.run.profiles=local spring-boot:run -pl application-spring
 ```
 
 The service will be available at localhost and your specified server port.

--- a/application-common/environment/pom.xml
+++ b/application-common/environment/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-environment</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits Server common environment</name>
 

--- a/application-common/environment/pom.xml
+++ b/application-common/environment/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-environment</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits Server common environment</name>
 

--- a/application-common/pom.xml
+++ b/application-common/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits Server common</name>

--- a/application-common/pom.xml
+++ b/application-common/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits Server common</name>

--- a/application-common/routing/pom.xml
+++ b/application-common/routing/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-routing</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits Server common routing</name>
 

--- a/application-common/routing/pom.xml
+++ b/application-common/routing/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-routing</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits Server common routing</name>
 

--- a/application-common/utils/pom.xml
+++ b/application-common/utils/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-middleware-config</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits Server common middleware config</name>
 

--- a/application-common/utils/pom.xml
+++ b/application-common/utils/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>application-common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-common-middleware-config</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits Server common middleware config</name>
 

--- a/application-spring/pom.xml
+++ b/application-spring/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-spring</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>jar</packaging>
     <name>Standalone Spring application, providing an AlpineBits Server with Open Data Hub (ODH) backend</name>

--- a/application-spring/pom.xml
+++ b/application-spring/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>application-spring</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>Standalone Spring application, providing an AlpineBits Server with Open Data Hub (ODH) backend</name>

--- a/application-spring/pom.xml
+++ b/application-spring/pom.xml
@@ -24,10 +24,6 @@ SPDX-License-Identifier: CC0-1.0
     <packaging>jar</packaging>
     <name>Standalone Spring application, providing an AlpineBits Server with Open Data Hub (ODH) backend</name>
 
-    <properties>
-        <janino.version>3.0.12</janino.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -36,10 +32,6 @@ SPDX-License-Identifier: CC0-1.0
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
@@ -54,11 +46,16 @@ SPDX-License-Identifier: CC0-1.0
             <artifactId>alpinebits-servlet-impl</artifactId>
         </dependency>
 
-        <!-- janino is used for logging evaluation (see logback.xml) -->
+        <!-- testing -->
         <dependency>
-            <groupId>org.codehaus.janino</groupId>
-            <artifactId>janino</artifactId>
-            <version>${janino.version}</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/AlpineBitsResource.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/AlpineBitsResource.java
@@ -25,14 +25,14 @@ import it.bz.opendatahub.alpinebits.servlet.middleware.StatisticsMiddleware;
 import it.bz.opendatahub.alpinebitsserver.application.common.routing.RoutingMiddlewareProvider;
 import it.bz.opendatahub.alpinebitsserver.application.spring.middleware.MultipartFormExtractorMiddleware;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.middleware.OdhBackendServiceProvidingMiddleware;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.PostConstruct;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;

--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluator.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluator.java
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.opendatahub.alpinebitsserver.application.spring.logging;
+
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.boolex.EventEvaluatorBase;
+
+/**
+ * A logback logging evaluator that checks if the MDC contains a "requestId" entry and,
+ * depending on configuration, evaluates to true if the requestId is present or missing.
+ */
+public class RequestIdExpressionEvaluator extends EventEvaluatorBase<ILoggingEvent> {
+
+    private boolean onlyWhenRequestIdPresent;
+    private boolean onlyWhenRequestIdMissing;
+
+    public void setOnlyWhenRequestIdPresent(boolean onlyWhenRequestIdPresent) {
+        this.onlyWhenRequestIdPresent = onlyWhenRequestIdPresent;
+    }
+
+    public void setOnlyWhenRequestIdMissing(boolean onlyWhenRequestIdMissing) {
+        this.onlyWhenRequestIdMissing = onlyWhenRequestIdMissing;
+    }
+
+    @Override
+    public void start() {
+        if (onlyWhenRequestIdPresent && onlyWhenRequestIdMissing) {
+            addError("Invalid config: both onlyWhenRequestIdPresent and onlyWhenRequestIdMissing are true.");
+            return;
+        }
+        super.start();
+    }
+
+    @Override
+    public boolean evaluate(ILoggingEvent event) {
+        if (!isStarted()) {
+            return false;
+        }
+
+        String requestId = event.getMDCPropertyMap().get("requestId");
+        boolean present = requestId != null;
+
+        if (onlyWhenRequestIdPresent) {
+            return present;
+        }
+
+        if (onlyWhenRequestIdMissing) {
+            return !present;
+        }
+
+        // If neither flag is set, then default to false
+        return false;
+    }
+
+
+}

--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluator.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluator.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: MPL-2.0
+
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
+++ b/application-spring/src/main/java/it/bz/opendatahub/alpinebitsserver/application/spring/middleware/MultipartFormExtractorMiddleware.java
@@ -17,11 +17,11 @@ import it.bz.opendatahub.alpinebits.middleware.Context;
 import it.bz.opendatahub.alpinebits.middleware.Middleware;
 import it.bz.opendatahub.alpinebits.middleware.MiddlewareChain;
 import it.bz.opendatahub.alpinebits.servlet.ServletContextKey;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
 import org.apache.commons.io.IOUtils;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.Part;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;

--- a/application-spring/src/main/resources/logback.xml
+++ b/application-spring/src/main/resources/logback.xml
@@ -9,8 +9,8 @@ SPDX-License-Identifier: CC0-1.0
 <configuration>
     <appender name="ConsoleWithRequestId" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
-                <expression>return (mdc.get("requestId") != null);</expression>
+            <evaluator class="it.bz.opendatahub.alpinebitsserver.application.spring.logging.RequestIdExpressionEvaluator">
+                <onlyWhenRequestIdPresent>true</onlyWhenRequestIdPresent>
             </evaluator>
             <OnMismatch>DENY</OnMismatch>
             <OnMatch>ACCEPT</OnMatch>
@@ -23,8 +23,8 @@ SPDX-License-Identifier: CC0-1.0
     </appender>
     <appender name="ConsoleWithoutRequestId" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
-                <expression>return (mdc.get("requestId") == null);</expression>
+            <evaluator class="it.bz.opendatahub.alpinebitsserver.application.spring.logging.RequestIdExpressionEvaluator">
+                <onlyWhenRequestIdMissing>true</onlyWhenRequestIdMissing>
             </evaluator>
             <OnMismatch>DENY</OnMismatch>
             <OnMatch>ACCEPT</OnMatch>

--- a/application-spring/src/test/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluatorTest.java
+++ b/application-spring/src/test/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluatorTest.java
@@ -1,0 +1,116 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.opendatahub.alpinebitsserver.application.spring.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for {@link RequestIdExpressionEvaluator}.
+ */
+public class RequestIdExpressionEvaluatorTest {
+
+    @Test
+    void start_shouldLogError_WhenBothConfigParamsAreTrue() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdPresent(true);
+        evaluator.setOnlyWhenRequestIdMissing(true);
+
+        // should not throw and should not be started when both flags are true
+        evaluator.start();
+        assertFalse(evaluator.isStarted());
+
+        // event with requestId should still evaluate to false because evaluator is not started
+        ILoggingEvent eventWithRequestId = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(eventWithRequestId.getMDCPropertyMap()).thenReturn(
+                Map.of("requestId", "id-123")
+        );
+
+        assertFalse(evaluator.evaluate(eventWithRequestId));
+    }
+
+    @Test
+    void evaluate_returnsTrue_whenRequestIdPresentFlagIsSetAndRequestIdExists() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdPresent(true);
+        evaluator.start();
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(Map.of("requestId", "id-123"));
+
+        assertTrue(evaluator.evaluate(event));
+    }
+
+    @Test
+    void evaluate_returnsFalse_whenRequestIdPresentFlagIsSetAndRequestIdMissing() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdPresent(true);
+        evaluator.start();
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(Map.of());
+
+        assertFalse(evaluator.evaluate(event));
+    }
+
+    @Test
+    void evaluate_returnsTrue_whenRequestIdMissingFlagIsSetAndRequestIdMissing() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdMissing(true);
+        evaluator.start();
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(Map.of());
+
+        assertTrue(evaluator.evaluate(event));
+    }
+
+    @Test
+    void evaluate_returnsFalse_whenRequestIdMissingFlagIsSetAndRequestIdExists() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdMissing(true);
+        evaluator.start();
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(Map.of("requestId", "id-123"));
+
+        assertFalse(evaluator.evaluate(event));
+    }
+
+    @Test
+    void evaluate_returnsFalse_whenNoFlagsAreSet() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.start();
+
+        ILoggingEvent eventWithRequestId = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(eventWithRequestId.getMDCPropertyMap()).thenReturn(Map.of("requestId", "id-123"));
+
+        ILoggingEvent eventWithoutRequestId = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(eventWithoutRequestId.getMDCPropertyMap()).thenReturn(Map.of());
+
+        assertFalse(evaluator.evaluate(eventWithRequestId));
+        assertFalse(evaluator.evaluate(eventWithoutRequestId));
+    }
+
+    @Test
+    void evaluate_returnsFalse_whenEvaluatorNotStarted() {
+        RequestIdExpressionEvaluator evaluator = new RequestIdExpressionEvaluator();
+        evaluator.setOnlyWhenRequestIdPresent(true);
+
+        ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
+        Mockito.when(event.getMDCPropertyMap()).thenReturn(Map.of("requestId", "id-123"));
+
+        assertFalse(evaluator.evaluate(event));
+    }
+
+}

--- a/application-spring/src/test/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluatorTest.java
+++ b/application-spring/src/test/java/it/bz/opendatahub/alpinebitsserver/application/spring/logging/RequestIdExpressionEvaluatorTest.java
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: NOI Techpark <digital@noi.bz.it>
+//
+// SPDX-License-Identifier: MPL-2.0
+
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -1,13 +1,13 @@
-FROM maven:3-jdk-8-alpine as base
+FROM maven:3.9-eclipse-temurin-25-alpine AS base
 
 RUN mkdir -p /code
 WORKDIR /code
 
 # Dev
-FROM base as dev
+FROM base AS dev
 
 # Build
-FROM base as build
+FROM base AS build
 
 COPY ./ /code
 RUN ls -ls && mvn -DskipTests install

--- a/odh-backend/api/pom.xml
+++ b/odh-backend/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-backend</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend-api</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>ODH backend API</name>
 

--- a/odh-backend/api/pom.xml
+++ b/odh-backend/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-backend</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend-api</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>ODH backend API</name>
 

--- a/odh-backend/api/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/OdhClient.java
+++ b/odh-backend/api/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/OdhClient.java
@@ -10,8 +10,9 @@
 
 package it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
+
 import java.util.Map;
 
 /**
@@ -21,36 +22,36 @@ public interface OdhClient {
 
     /**
      * Fetch data from ODH.
-     *
+     * <p>
      * The data is read from <code>path</code> using the provided HTTP
      * <code>method</code>. The <code>queryParams</code> are appended
      * to the url and the <code>body</code> is send as the request body.
      * The result is expected of the type defined by <code>genericType</code>.
      *
-     * @param path fetch data from this path
-     * @param method use this HTTP method for the fetch
+     * @param path        fetch data from this path
+     * @param method      use this HTTP method for the fetch
      * @param queryParams append these parameters to the url
-     * @param body send this body as the request body
+     * @param body        send this body as the request body
      * @param genericType the result is expected to be of this type
-     * @param <T> result type
+     * @param <T>         result type
      * @return data of type T fetched from ODH
      */
     <T> T fetch(String path, String method, Map<String, String> queryParams, Entity<?> body, GenericType<T> genericType);
 
     /**
      * Fetch data from ODH.
-     *
+     * <p>
      * The data is read from <code>path</code> using the provided HTTP
      * <code>method</code>. The <code>queryParams</code> are appended
      * to the url and the <code>body</code> is send as the request body.
      * The result is expected to be an instance of <code>resultClass</code>.
      *
-     * @param path fetch data from this path
-     * @param method use this HTTP method for the fetch
+     * @param path        fetch data from this path
+     * @param method      use this HTTP method for the fetch
      * @param queryParams append these parameters to the url
-     * @param body send this body as the request body
+     * @param body        send this body as the request body
      * @param resultClass the result is expected to be an instance of this class
-     * @param <T> result type
+     * @param <T>         result type
      * @return data of type T fetched from ODH
      */
     <T> T fetch(String path, String method, Map<String, String> queryParams, Entity<?> body, Class<T> resultClass);

--- a/odh-backend/impl/pom.xml
+++ b/odh-backend/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-backend</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend-impl</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>ODH backend impl</name>
 

--- a/odh-backend/impl/pom.xml
+++ b/odh-backend/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-backend</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend-impl</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>ODH backend impl</name>
 

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/OdhClientImpl.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/OdhClientImpl.java
@@ -15,22 +15,22 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.auth.AuthProvider;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.auth.AuthenticationException;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.serialization.OtaJaxbModule;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.Map;
 
 /**
@@ -127,13 +127,13 @@ public class OdhClientImpl implements AuthenticatedOdhClient {
         ObjectMapper om = new ObjectMapper();
         om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        om.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        om.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
 
         // Add module to support the Java Date/Time API
         om.registerModule(new JavaTimeModule());
 
         // Add module for better JAXB support
-        om.registerModule(new JaxbAnnotationModule());
+        om.registerModule(new JakartaXmlBindAnnotationModule());
 
         // Add serialization module for AlpineBits 2020-10 (JAXBElement serializations)
         om.registerModule(new OtaJaxbModule());

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/auth/OpenIdAuthProvider.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/auth/OpenIdAuthProvider.java
@@ -11,13 +11,13 @@
 package it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.auth;
 
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.ApiKeyResponse;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
 import java.util.Objects;
 
 /**

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/JAXBElementDeserializer.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/JAXBElementDeserializer.java
@@ -18,11 +18,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
 import it.bz.opendatahub.alpinebits.xml.schema.ota.FormattedTextTextType;
 import it.bz.opendatahub.alpinebits.xml.schema.ota.ObjectFactory;
+import jakarta.xml.bind.JAXBElement;
 
-import javax.xml.bind.JAXBElement;
 import java.io.IOException;
 
 /**
@@ -46,7 +46,7 @@ public class JAXBElementDeserializer extends JsonDeserializer<JAXBElement> {
     public JAXBElementDeserializer() {
         mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        mapper.registerModule(new JaxbAnnotationModule());
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
     }
 
     @Override

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/JAXBElementSerializer.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/JAXBElementSerializer.java
@@ -17,14 +17,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.fasterxml.jackson.module.jakarta.xmlbind.JakartaXmlBindAnnotationModule;
+import jakarta.xml.bind.JAXBElement;
 
-import javax.xml.bind.JAXBElement;
 import java.io.IOException;
 
 /**
  * Serialize {@link JAXBElement} instances into JSON data.
- *
+ * <p>
  * The serialized JSON contains the {@link JAXBElement#getValue()} and type
  * information taken from {@link JAXBElement#getDeclaredType()} to simplify
  * the deserialization.
@@ -37,8 +37,8 @@ public class JAXBElementSerializer extends JsonSerializer<JAXBElement> {
 
     public JAXBElementSerializer() {
         mapper = new ObjectMapper();
-        mapper.registerModule(new JaxbAnnotationModule());
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.registerModule(new JakartaXmlBindAnnotationModule());
+        mapper.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
     }
 
     @Override

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/OtaJaxbModule.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/client/serialization/OtaJaxbModule.java
@@ -12,14 +12,16 @@ package it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.client.serializ
 
 import com.fasterxml.jackson.core.json.PackageVersion;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import jakarta.xml.bind.JAXBElement;
 
-import javax.xml.bind.JAXBElement;
+import java.io.Serial;
 
 /**
  * Custom Jackson serializer / deserializer module for ODH support.
  */
 public class OtaJaxbModule extends SimpleModule {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public OtaJaxbModule() {

--- a/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/service/OdhBackendServiceImpl.java
+++ b/odh-backend/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/backend/odhclient/service/OdhBackendServiceImpl.java
@@ -17,12 +17,12 @@ import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.dto.Accommodatio
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.dto.PullWrapper;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.dto.PushWrapper;
 import it.bz.opendatahub.alpinebitsserver.odh.backend.odhclient.exception.OdhBackendException;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +76,7 @@ public class OdhBackendServiceImpl implements OdhBackendService {
                     HttpMethod.GET,
                     queryParams,
                     null,
-                    new GenericType<List<AccommodationRoom>>() {
+                    new GenericType<>() {
                     }
             );
             return Optional.of(accommodationRooms);
@@ -138,7 +138,7 @@ public class OdhBackendServiceImpl implements OdhBackendService {
                     HttpMethod.GET,
                     queryParams,
                     null,
-                    new GenericType<List<PullWrapper<OTAHotelDescriptiveInfoRS>>>() {
+                    new GenericType<>() {
                     }
             );
 
@@ -146,15 +146,15 @@ public class OdhBackendServiceImpl implements OdhBackendService {
                 return Optional.empty();
             }
 
-            return Optional.of(result.get(0).getMessage());
+            return Optional.of(result.getFirst().getMessage());
         } catch (Exception e) {
             return handleException(e);
         }
     }
 
     private <T> Optional<T> handleException(Exception e) {
-        if (e instanceof WebApplicationException) {
-            if (Response.Status.NOT_FOUND.equals(((WebApplicationException) e).getResponse().getStatusInfo())) {
+        if (e instanceof WebApplicationException webApplicationException) {
+            if (Response.Status.NOT_FOUND.equals(webApplicationException.getResponse().getStatusInfo())) {
                 return Optional.empty();
             }
             throw new OdhBackendException(e.getMessage(), e);

--- a/odh-backend/pom.xml
+++ b/odh-backend/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>ODH backend</name>

--- a/odh-backend/pom.xml
+++ b/odh-backend/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-backend</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>pom</packaging>
     <name>ODH backend</name>

--- a/odh-freerooms/api/pom.xml
+++ b/odh-freerooms/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-freerooms</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms-api</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits FreeRooms action with ODH backend API</name>
 

--- a/odh-freerooms/api/pom.xml
+++ b/odh-freerooms/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-freerooms</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms-api</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits FreeRooms action with ODH backend API</name>
 

--- a/odh-freerooms/impl/pom.xml
+++ b/odh-freerooms/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-freerooms</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms-impl</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits FreeRooms action with ODH backend impl</name>
 

--- a/odh-freerooms/impl/pom.xml
+++ b/odh-freerooms/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-freerooms</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms-impl</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits FreeRooms action with ODH backend impl</name>
 

--- a/odh-freerooms/impl/pom.xml
+++ b/odh-freerooms/impl/pom.xml
@@ -56,11 +56,6 @@ SPDX-License-Identifier: CC0-1.0
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/odh-freerooms/pom.xml
+++ b/odh-freerooms/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits FreeRooms action with ODH backend</name>

--- a/odh-freerooms/pom.xml
+++ b/odh-freerooms/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-freerooms</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits FreeRooms action with ODH backend</name>

--- a/odh-inventory/api/pom.xml
+++ b/odh-inventory/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-inventory</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory-api</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits Inventory action with ODH backend API</name>
 

--- a/odh-inventory/api/pom.xml
+++ b/odh-inventory/api/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-inventory</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory-api</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits Inventory action with ODH backend API</name>
 

--- a/odh-inventory/impl/pom.xml
+++ b/odh-inventory/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-inventory</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory-impl</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <name>AlpineBits Inventory action with ODH backend impl</name>
 

--- a/odh-inventory/impl/pom.xml
+++ b/odh-inventory/impl/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>odh-inventory</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory-impl</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <name>AlpineBits Inventory action with ODH backend impl</name>
 

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/ContactInfosTypeBuilder.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/ContactInfosTypeBuilder.java
@@ -34,6 +34,7 @@ import java.util.Set;
 /**
  * Helper class to build {@link ContactInfosType} instances.
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public final class ContactInfosTypeBuilder {
 
     private ContactInfosTypeBuilder() {
@@ -73,6 +74,7 @@ public final class ContactInfosTypeBuilder {
         return Optional.of(contactInfosType);
     }
 
+    @SuppressWarnings("checkstyle:NPathComplexity")
     private static Optional<AddressesType> extractAddressesType(Accommodation accommodation) {
         if (accommodation.getAccoDetailMap() == null || accommodation.getAccoDetailMap().isEmpty()) {
             return Optional.empty();

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/ContactInfosTypeBuilder.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/ContactInfosTypeBuilder.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Helper class to build {@link ContactInfosType} instances.
@@ -105,7 +104,7 @@ public final class ContactInfosTypeBuilder {
                     return isAddressEmpty(address) ? null : address;
                 })
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
 
         // If there are no addresses, return an empty Optional
         if (addresses.isEmpty()) {
@@ -160,7 +159,8 @@ public final class ContactInfosTypeBuilder {
                     phone.setPhoneNumber(number);
                     phone.setPhoneTechType(phoneTechType);
                     return phone;
-                }).collect(Collectors.toList());
+                })
+                .toList();
     }
 
     private static Optional<EmailsType> extractEmailsType(Accommodation accommodation) {
@@ -179,7 +179,7 @@ public final class ContactInfosTypeBuilder {
                     result.setValue(email);
                     return result;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         // If there are no emails, return an empty Optional
         if (emails.isEmpty()) {
@@ -206,7 +206,7 @@ public final class ContactInfosTypeBuilder {
                         result.setValue(website);
                         return result;
                     })
-                    .collect(Collectors.toList());
+                    .toList();
 
             urLsType.getURLS().addAll(urls);
         }

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/HotelInfoTypeBuilder.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/HotelInfoTypeBuilder.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 /**
  * Helper class to build {@link HotelInfoType} instances.
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public final class HotelInfoTypeBuilder {
 
     private HotelInfoTypeBuilder() {

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/HotelInfoTypeBuilder.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/HotelInfoTypeBuilder.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Helper class to build {@link HotelInfoType} instances.
@@ -132,7 +131,7 @@ public final class HotelInfoTypeBuilder {
                     return buildTextItem(language, description);
                 })
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
 
         if (textItemList.isEmpty()) {
             return Optional.empty();
@@ -184,12 +183,13 @@ public final class HotelInfoTypeBuilder {
                                 return buildImageDescription(language, value);
                             })
                             .filter(Objects::nonNull)
-                            .collect(Collectors.toList());
+                            .toList();
 
                     imageItem.getDescriptions().addAll(descriptions);
 
                     return imageItem;
-                }).collect(Collectors.toList());
+                })
+                .toList();
 
         ImageItemsType imageItemsType = new ImageItemsType();
         imageItemsType.getImageItems().addAll(imageItemList);
@@ -281,7 +281,7 @@ public final class HotelInfoTypeBuilder {
                     return null;
                 })
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
 
         if (serviceList.isEmpty()) {
             return Optional.empty();

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/InventoryPullMapper.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/InventoryPullMapper.java
@@ -40,8 +40,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Mapping utility class for inventory pull actions.
@@ -88,7 +88,7 @@ public class InventoryPullMapper {
                         }
                     }
                     // Sort by RoomID (if such a value exists)
-                    realRooms.sort(Comparator.comparing(o -> o.getTypeRooms().isEmpty() ? "" : o.getTypeRooms().get(0).getRoomID()));
+                    realRooms.sort(Comparator.comparing(o -> o.getTypeRooms().isEmpty() ? "" : o.getTypeRooms().getFirst().getRoomID()));
 
                     // Concatenate room category information and all real rooms
                     List<GuestRoom> allRooms = new ArrayList<>();
@@ -98,7 +98,7 @@ public class InventoryPullMapper {
                     return allRooms;
                 })
                 .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+                .toList();
 
         return buildOtaHotelDescriptiveInfo(guestRooms);
     }
@@ -124,7 +124,7 @@ public class InventoryPullMapper {
                     guestRoom.setMultimediaDescriptions(multimediaDescriptionsType);
                     return guestRoom;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         return buildOtaHotelDescriptiveInfo(guestRooms);
     }
@@ -196,8 +196,8 @@ public class InventoryPullMapper {
     private Amenities buildAmenities(AccommodationRoom room) {
         List<Amenity> amenitiesWithCode = room.getFeatures()
                 .stream()
-                .filter(feature -> feature.getRoomAmenityCodes() != null)
                 .map(Feature::getRoomAmenityCodes)
+                .filter(Objects::nonNull)
                 .flatMap(List::stream)
                 .distinct()
                 .sorted(Comparator.comparingInt(Integer::intValue))
@@ -206,7 +206,7 @@ public class InventoryPullMapper {
                     amenity.setRoomAmenityCode(roomAmenityCode.toString());
                     return amenity;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         Amenities amenities = new Amenities();
         amenities.getAmenities().addAll(amenitiesWithCode);
@@ -227,7 +227,7 @@ public class InventoryPullMapper {
                     description.setValue(value.getName());
                     return description;
                 })
-                .collect(Collectors.toList());
+                .toList();
         TextItem textItem = new TextItem();
         textItem.getDescriptions().addAll(descriptions);
 
@@ -254,7 +254,7 @@ public class InventoryPullMapper {
                     description.setValue(value.getLongdesc());
                     return description;
                 })
-                .collect(Collectors.toList());
+                .toList();
         TextItem textItem = new TextItem();
         textItem.getDescriptions().addAll(descriptions);
 
@@ -289,7 +289,7 @@ public class InventoryPullMapper {
 
                     return imageItem;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         ImageItemsType imageItemsType = new ImageItemsType();
         imageItemsType.getImageItems().addAll(imageItems);

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/InventoryPullMapper.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/common/InventoryPullMapper.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 /**
  * Mapping utility class for inventory pull actions.
  */
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class InventoryPullMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(InventoryPullMapper.class);

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2018_10/InventoryHotelInfoPullAdapter.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2018_10/InventoryHotelInfoPullAdapter.java
@@ -21,7 +21,6 @@ import it.bz.opendatahub.alpinebits.xml.schema.ota.URLsType.URL;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This middleware removes elements and attributes that are not allowed in AlpineBits 2018-10
@@ -64,7 +63,7 @@ public final class InventoryHotelInfoPullAdapter implements Middleware {
         // Set AreaID to null (AreaID is allowed in AlpineBits 2020-10)
         if (otaHotelDescriptiveInfoRS.getHotelDescriptiveContents() != null
                 && !otaHotelDescriptiveInfoRS.getHotelDescriptiveContents().getHotelDescriptiveContents().isEmpty()) {
-            otaHotelDescriptiveInfoRS.getHotelDescriptiveContents().getHotelDescriptiveContents().get(0).setAreaID(null);
+            otaHotelDescriptiveInfoRS.getHotelDescriptiveContents().getHotelDescriptiveContents().getFirst().setAreaID(null);
         }
 
         extractContactInfoRootType(otaHotelDescriptiveInfoRS).ifPresent(contactInfoRootType -> {
@@ -82,7 +81,7 @@ public final class InventoryHotelInfoPullAdapter implements Middleware {
             removeUnsupportedURLs(contactInfoRootType);
             // A ContactInfos element must have URLs to be valid
             if (contactInfoRootType.getURLs() == null) {
-                otaHotelDescriptiveInfoRS.getHotelDescriptiveContents().getHotelDescriptiveContents().get(0).setContactInfos(null);
+                otaHotelDescriptiveInfoRS.getHotelDescriptiveContents().getHotelDescriptiveContents().getFirst().setContactInfos(null);
             }
         });
     }
@@ -90,10 +89,10 @@ public final class InventoryHotelInfoPullAdapter implements Middleware {
     private Optional<ContactInfoRootType> extractContactInfoRootType(OTAHotelDescriptiveInfoRS ota) {
         if (ota.getHotelDescriptiveContents() != null
                 && !ota.getHotelDescriptiveContents().getHotelDescriptiveContents().isEmpty()
-                && ota.getHotelDescriptiveContents().getHotelDescriptiveContents().get(0).getContactInfos() != null
-                && !ota.getHotelDescriptiveContents().getHotelDescriptiveContents().get(0).getContactInfos().getContactInfos().isEmpty()
+                && ota.getHotelDescriptiveContents().getHotelDescriptiveContents().getFirst().getContactInfos() != null
+                && !ota.getHotelDescriptiveContents().getHotelDescriptiveContents().getFirst().getContactInfos().getContactInfos().isEmpty()
         ) {
-            return Optional.of(ota.getHotelDescriptiveContents().getHotelDescriptiveContents().get(0).getContactInfos().getContactInfos().get(0));
+            return Optional.of(ota.getHotelDescriptiveContents().getHotelDescriptiveContents().getFirst().getContactInfos().getContactInfos().getFirst());
         }
         return Optional.empty();
     }
@@ -111,7 +110,7 @@ public final class InventoryHotelInfoPullAdapter implements Middleware {
                     result.setValue(url.getValue());
                     return result;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         if (urls.isEmpty()) {
             contactInfoRootType.setURLs(null);

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2020_10/adapter/policies/CancelPenaltyTypeAdapter.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2020_10/adapter/policies/CancelPenaltyTypeAdapter.java
@@ -13,11 +13,10 @@ package it.bz.opendatahub.alpinebitsserver.odh.inventory.v_2020_10.adapter.polic
 import it.bz.opendatahub.alpinebits.xml.schema.ota.CancelPenaltyType;
 import it.bz.opendatahub.alpinebits.xml.schema.ota.FormattedTextTextType;
 import it.bz.opendatahub.alpinebits.xml.schema.ota.ParagraphType;
+import jakarta.xml.bind.JAXBElement;
 
-import javax.xml.bind.JAXBElement;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This adapter is used to remove elements from {@link CancelPenaltyType} that are not
@@ -66,7 +65,7 @@ public final class CancelPenaltyTypeAdapter {
             if (paragraphType.getTextsAndImagesAndURLS() != null) {
                 List<JAXBElement<?>> result = paragraphType.getTextsAndImagesAndURLS().stream()
                         .filter(jaxbElement -> jaxbElement.getValue() instanceof FormattedTextTextType)
-                        .collect(Collectors.toList());
+                        .toList();
 
                 result.forEach(jaxbElement -> ((FormattedTextTextType) jaxbElement.getValue()).setFormatted(null));
 

--- a/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2020_10/adapter/policies/ParagraphTypeAdapter.java
+++ b/odh-inventory/impl/src/main/java/it/bz/opendatahub/alpinebitsserver/odh/inventory/v_2020_10/adapter/policies/ParagraphTypeAdapter.java
@@ -12,10 +12,9 @@ package it.bz.opendatahub.alpinebitsserver.odh.inventory.v_2020_10.adapter.polic
 
 import it.bz.opendatahub.alpinebits.xml.schema.ota.FormattedTextTextType;
 import it.bz.opendatahub.alpinebits.xml.schema.ota.ParagraphType;
+import jakarta.xml.bind.JAXBElement;
 
-import javax.xml.bind.JAXBElement;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This adapter is used to remove elements from {@link ParagraphType} elements that are not
@@ -41,7 +40,7 @@ public final class ParagraphTypeAdapter {
         if (paragraphType.getTextsAndImagesAndURLS() != null) {
             List<JAXBElement<?>> result = paragraphType.getTextsAndImagesAndURLS().stream()
                     .filter(jaxbElement -> jaxbElement.getValue() instanceof FormattedTextTextType)
-                    .collect(Collectors.toList());
+                    .toList();
 
             result.forEach(jaxbElement -> ((FormattedTextTextType) jaxbElement.getValue()).setFormatted(null));
 

--- a/odh-inventory/pom.xml
+++ b/odh-inventory/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>5.0.0</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits Inventory action with ODH backend</name>

--- a/odh-inventory/pom.xml
+++ b/odh-inventory/pom.xml
@@ -14,12 +14,12 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
         <artifactId>alpinebitsserver-odh-root</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>odh-inventory</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits Inventory action with ODH backend</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,6 @@ SPDX-License-Identifier: CC0-1.0
         <module>odh-freerooms</module>
     </modules>
 
-<!--    <repositories>-->
-<!--        <repository>-->
-<!--            <id>maven-repo.opendatahub.com</id>-->
-<!--            <url>http://it.bz.opendatahub.s3-website-eu-west-1.amazonaws.com/release</url>-->
-<!--        </repository>-->
-<!--    </repositories>-->
-
     <properties>
         <odh-alpinebits.version>4.0.1</odh-alpinebits.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,13 @@ SPDX-License-Identifier: CC0-1.0
     <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
+
     <name>AlpineBits Server with ODH as backend</name>
+    <description>Modular AlpineBits Server implementation using the AlpineBits Library and Open Data Hub (ODH) as backend.</description>
+    <url>https://www.alpinebits.org/</url>
+    <scm>
+        <url>https://github.com/noi-techpark/opendatahub-alpinebits-hoteldata-server</url>
+    </scm>
 
     <modules>
         <module>application-common</module>
@@ -157,47 +163,47 @@ SPDX-License-Identifier: CC0-1.0
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-environment</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-middleware-config</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-routing</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-backend-api</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-backend-impl</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-freerooms-api</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-freerooms-impl</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-inventory-api</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-inventory-impl</artifactId>
-                <version>6.0.0-SNAPSHOT</version>
+                <version>6.0.0</version>
             </dependency>
 
             <!-- AlpineBits library dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: CC0-1.0
 
     <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
     <artifactId>alpinebitsserver-odh-root</artifactId>
-    <version>5.0.0</version>
+    <version>6.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>AlpineBits Server with ODH as backend</name>
@@ -221,47 +221,47 @@ SPDX-License-Identifier: CC0-1.0
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-environment</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-middleware-config</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-routing</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-backend-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-backend-impl</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-freerooms-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-freerooms-impl</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-inventory-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>odh-inventory-impl</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- AlpineBits library dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@ SPDX-License-Identifier: CC0-1.0
 
     <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
     <artifactId>alpinebitsserver-odh-root</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,6 @@ SPDX-License-Identifier: CC0-1.0
 
         <testng.version>7.11.0</testng.version>
         <rest-assured.version>5.5.6</rest-assured.version>
-        <!-- Provided and used by Mockito. Contains a java-agent for inline-mocks to make Mockito work with modern Java versions -->
-        <bytebuddy.version>1.17.8</bytebuddy.version>
 
         <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -567,11 +565,6 @@ SPDX-License-Identifier: CC0-1.0
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.version}/byte-buddy-agent-${bytebuddy.version}.jar
-                    </argLine>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@ SPDX-License-Identifier: CC0-1.0
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.18</version>
+        <version>4.0.0</version>
         <relativePath/>
     </parent>
 
@@ -35,29 +35,28 @@ SPDX-License-Identifier: CC0-1.0
     </modules>
 
     <properties>
-        <odh-alpinebits.version>4.0.1</odh-alpinebits.version>
+        <odh-alpinebits.version>5.0.0</odh-alpinebits.version>
 
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-        <checkstyle-maven.version>3.1.1</checkstyle-maven.version>
-        <checkstyle.version>8.29</checkstyle.version>
+        <checkstyle-maven.version>3.6.0</checkstyle-maven.version>
         <maven-pmd-plugin.version>3.10.0</maven-pmd-plugin.version>
         <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
         <jacoco.version>0.8.2</jacoco.version>
-
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-        <dependency-check-maven.version>5.0.0</dependency-check-maven.version>
+        <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
         <gitflow-maven-plugin.version>1.10.0</gitflow-maven-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 
-        <testng.version>7.5.1</testng.version>
-        <arquillian.version>1.8.0.Final</arquillian.version>
+        <testng.version>7.11.0</testng.version>
         <rest-assured.version>5.5.6</rest-assured.version>
+        <!-- Provided and used by Mockito. Contains a java-agent for inline-mocks to make Mockito work with modern Java versions -->
+        <bytebuddy.version>1.17.8</bytebuddy.version>
 
-        <java.version>1.8</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipTests>false</skipTests>
@@ -155,62 +154,6 @@ SPDX-License-Identifier: CC0-1.0
 
     <dependencyManagement>
         <dependencies>
-            <!--
-                Use current version of commons-io to fix a security vulnerability
-                introduced by org.apache.commons:commons-fileupload2-javax in
-                alpinebits-servlet-impl module.
-            -->
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.20.0</version>
-            </dependency>
-            <!--
-                Use current version of commons-codec to fix a security vulnerability
-                introduced by io.rest-assured:rest-assured
-            -->
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.19.0</version>
-            </dependency>
-            <!--
-                Use most up-to-date compatible version of jackson-core to fix a security vulnerability
-                introduced by org.glassfish.jersey.media:jersey-media-json-jackson
-            -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>2.15.0</version>
-            </dependency>
-            <!--
-                Use most up-to-date compatible version of logback-classic to fix a security vulnerability
-                introduced by org.springframework.boot:spring-boot-starter-logging
-            -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>1.2.13</version>
-            </dependency>
-            <!--
-                Use most up-to-date compatible version of logback-core to fix a security vulnerability
-                introduced by org.springframework.boot:spring-boot-starter-logging
-            -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>1.2.13</version>
-            </dependency>
-            <!--
-                Use current version of commons-lang3 to fix a security vulnerability
-                introduced by io.rest-assured:rest-assured
-            -->
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
-            </dependency>
-
             <dependency>
                 <groupId>it.bz.opendatahub.alpinebitsserver.odh</groupId>
                 <artifactId>application-common-environment</artifactId>
@@ -358,20 +301,6 @@ SPDX-License-Identifier: CC0-1.0
                 <version>${rest-assured.version}</version>
                 <scope>test</scope>
             </dependency>
-
-            <!-- Integration test dependencies -->
-            <dependency>
-                <groupId>org.jboss.arquillian.testng</groupId>
-                <artifactId>arquillian-testng-container</artifactId>
-                <version>${arquillian.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian.container</groupId>
-                <artifactId>arquillian-tomcat-embedded-8</artifactId>
-                <version>1.1.0.Final</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -384,8 +313,8 @@ SPDX-License-Identifier: CC0-1.0
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>25</source>
+                        <target>25</target>
                     </configuration>
                 </plugin>
 
@@ -403,7 +332,7 @@ SPDX-License-Identifier: CC0-1.0
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                        <version>[1.8,)</version>
+                                        <version>[25,)</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
                                         <version>[3.2.1,)</version>
@@ -440,13 +369,6 @@ SPDX-License-Identifier: CC0-1.0
                             </goals>
                         </execution>
                     </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>${checkstyle.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
 
                 <!-- Unit tests -->
@@ -472,17 +394,6 @@ SPDX-License-Identifier: CC0-1.0
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
-                    <configuration>
-                        <encoding>UTF-8</encoding>
-                        <!--
-                            ISSUE: org.apache.maven.surefire.booter.SurefireBooterForkException: The forked
-                                VM terminated without properly saying goodbye
-                            TEMP SOLUTION: set "useSystemClassLoader" to false
-                            See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925 and
-                                https://issues.apache.org/jira/browse/SUREFIRE-1588
-                        -->
-                        <useSystemClassLoader>false</useSystemClassLoader>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>integration-test</id>
@@ -605,7 +516,6 @@ SPDX-License-Identifier: CC0-1.0
                     </executions>
                     <configuration>
                         <failBuildOnCVSS>8</failBuildOnCVSS>
-                        <cveValidForHours>24</cveValidForHours>
                         <skipProvidedScope>true</skipProvidedScope>
                     </configuration>
                 </plugin>
@@ -651,6 +561,11 @@ SPDX-License-Identifier: CC0-1.0
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${bytebuddy.version}/byte-buddy-agent-${bytebuddy.version}.jar
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@ SPDX-License-Identifier: CC0-1.0
     </properties>
 
     <organization>
-        <name>IDM Südtirol - Alto Adige</name>
-        <url>https://www.idm-suedtirol.com</url>
+        <name>NOI Techpark - Alto Adige</name>
+        <url>https://noi.bz.it/</url>
     </organization>
 
     <developers>


### PR DESCRIPTION
This PR migrates the AlpineBits Server from Java 8 to to Java 25 (latest LTS).

The main reason for moving to Java 25 was that project dependencies were starting to drop support for Java 8, leaving the project with possibly unfixed problems or security vulnerabilities. The situation is way better with Java 25.

In addition to the Java version update, some dependencies were updated to their latest versions, and the code was adapted to use some of the new Java features (e.g., `List.of(...)`).

Other improvements include:

- usage of latest Spring Boot (4.0.0)
- update of deprecated code
- added descriptions, URLs and SCM information to pom.xml
- update of docker files to use Java 25 base images
- README update
